### PR TITLE
Ensure useDebounce cleans up timeout on unmount

### DIFF
--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,10 +1,18 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useEffect } from "react";
 
 export function useDebounce<Args extends unknown[]>(
   callback: (...args: Args) => void,
   delay: number
 ): (...args: Args) => void {
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return useCallback(
     (...args: Args) => {


### PR DESCRIPTION
## Summary
- clear any pending timeout in `useDebounce` on component unmount

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686623f1b3cc832d8660607bbb281cac