### PR TITLE
Fix parameter types for Next.js pages

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,9 +5,9 @@ import { redirect } from "next/navigation";
 export const dynamic = "force-dynamic";
 
 type Props = {
-  searchParams: Promise<{
+  searchParams: {
     message?: string;
-  }>;
+  };
 };
 
 export default async function LoginPage({ searchParams }: Props) {
@@ -16,7 +16,7 @@ export default async function LoginPage({ searchParams }: Props) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  const { message } = await searchParams;
+  const { message } = searchParams;
 
   if (session) {
     redirect("/dashboard");

--- a/app/tier-list/[id]/page.tsx
+++ b/app/tier-list/[id]/page.tsx
@@ -1,8 +1,7 @@
 import TierListLayout from "@/components/tier-list/TierListLayout";
 import { createClient } from "@/utils/supabase/server";
 
-export default async function TierListPage(props: { params: Promise<{ id: string }> }) {
-  const params = await props.params;
+export default async function TierListPage({ params }: { params: { id: string } }) {
   const supabase = await createClient();
 
   const { data: tierList, error } = await supabase.from("tier_lists").select("title").eq("id", params.id).single();


### PR DESCRIPTION
## Summary
- correct `searchParams` type in login page
- fix `params` type in tier-list page

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_686622590ce0832dbda5332c51d5d85d