### PR TITLE
[codex] Clean up unused bindings flagged by lint

### DIFF
--- a/app/file-explorer-demo/page.tsx
+++ b/app/file-explorer-demo/page.tsx
@@ -35,7 +35,7 @@ export default function FileExplorerDemo() {
     }
   };
 
-  const customFolderIcon = (folder: FolderItem) => {
+  const customFolderIcon = () => {
     return <Folder className="h-8 w-8 text-yellow-500" />;
   };
 

--- a/components/file-explorer/FileExplorer.tsx
+++ b/components/file-explorer/FileExplorer.tsx
@@ -19,10 +19,8 @@ import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import {
   FileExplorerProps,
   ExplorerItem,
-  FileItem,
   FolderItem,
   FileExplorerState,
-  FileExplorerEvents,
 } from "./types";
 import { FileExplorerHeader } from "./FileExplorerHeader";
 import { FileExplorerGrid } from "./FileExplorerGrid";
@@ -37,7 +35,6 @@ export function FileExplorer({
   onFolderClick,
   onFolderDoubleClick,
   onItemDelete,
-  onItemRename,
   renderFileIcon,
   renderFolderIcon,
   className = "",

--- a/components/file-explorer/storage/localStorageAdapter.ts
+++ b/components/file-explorer/storage/localStorageAdapter.ts
@@ -53,24 +53,6 @@ const findAndRemoveItem = (
   });
 };
 
-// Helper function to find parent folder recursively
-const findParentFolder = (
-  items: ExplorerItem[],
-  itemId: string,
-  parentId?: string
-): string | null => {
-  for (const item of items) {
-    if (item.type === "folder") {
-      if (item.items.some((child) => child.id === itemId)) {
-        return item.id;
-      }
-      const found = findParentFolder(item.items, itemId, item.id);
-      if (found) return found;
-    }
-  }
-  return parentId || null;
-};
-
 // Helper function to find item by ID recursively
 const findItemById = (
   items: ExplorerItem[],

--- a/components/tier-list/LocalTierListLayout.tsx
+++ b/components/tier-list/LocalTierListLayout.tsx
@@ -11,13 +11,10 @@ import MainContent from "./components/content/MainContent";
 import {
   useTierListDataStore,
   useTierListUIStore,
-  useCurrentPolyList,
   useSortedPolyLists,
   useLeftSidebarState,
   useRightSidebarState,
   useIsSheetOpen,
-  useIsDraggable,
-  useSelectedStatIndex,
   useHasHydrated,
   createPolyList,
 } from "@/stores";
@@ -42,8 +39,6 @@ export default function TierListLayout({
     updatePolyList,
     deletePolyList,
     setCurrentPolyListId,
-    updateStat,
-    setSortingConfigs,
   } = useTierListDataStore();
 
   const {
@@ -52,18 +47,14 @@ export default function TierListLayout({
     setLeftSidebarWidth,
     setRightSidebarWidth,
     setIsDraggable,
-    setSelectedStatIndex,
     setIsSheetOpen,
   } = useTierListUIStore();
 
   // Get computed values from stores
-  const currentPolyList = useCurrentPolyList();
   const sortedPolyLists = useSortedPolyLists();
   const leftSidebar = useLeftSidebarState();
   const rightSidebar = useRightSidebarState();
   const isSheetOpen = useIsSheetOpen();
-  const isDraggable = useIsDraggable();
-  const selectedStatIndex = useSelectedStatIndex();
 
   const leftSidebarRef = useRef<HTMLDivElement>(null);
   const rightSidebarRef = useRef<HTMLDivElement>(null);
@@ -109,21 +100,6 @@ export default function TierListLayout({
 
   const handlePolyListDelete = (polyListId: string) => {
     deletePolyList(polyListId);
-  };
-
-  const handleStatChange = (statIndex: number, newValue: number) => {
-    if (currentPolyList) {
-      updateStat(currentPolyList.id, statIndex, { value: newValue });
-    }
-  };
-
-  const handleStatUpdate = (
-    index: number,
-    change: { name?: string; value?: number }
-  ) => {
-    if (currentPolyList) {
-      updateStat(currentPolyList.id, index, change);
-    }
   };
 
   const handleStatCountChange = (newCount: number) => {

--- a/components/tier-list/TierListLayout.tsx
+++ b/components/tier-list/TierListLayout.tsx
@@ -14,10 +14,8 @@ export default function TierListLayout({
 
   const {
     tierListName,
-    statCount,
     currentPolyListId,
     polyLists,
-    currentPolyList,
     sortedPolyLists,
     setCurrentPolyListId,
     handleStatCountChange,

--- a/components/tier-list/components/layout/ResizableSidebar.tsx
+++ b/components/tier-list/components/layout/ResizableSidebar.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { ReactNode } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useDragHandlers } from "../../hooks/useDragHandlers";
 import { ResizableSidebarProps } from "../../types/layout.types";


### PR DESCRIPTION
## Summary
- remove unused bindings in the file explorer demo and file explorer components
- delete dead helper and layout handlers that were no longer referenced
- clear the current lint warnings without changing runtime behavior

## Why
These files had accumulated unused imports, props, and helpers. Keeping them around made `eslint` noisy and obscured the live code paths during review.

## Impact
- `npm run lint` is now clean
- no behavior changes were introduced; this is a maintenance-only cleanup

## Validation
- `npm run lint`
- `npm test --silent`
- `npm run type-check`
- `npm run build`